### PR TITLE
Remove quarkus-awt dependency from quarkus-tika

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -21,10 +21,6 @@
             <artifactId>quarkus-tika</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-awt-deployment</artifactId>
-        </dependency>
         <!-- the tika parsers depend on http-client -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -16,6 +16,14 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
+        <!-- AWT -->
+        <!-- org.apache.pdfbox.pdmodel.common.PDRectangle.toGeneralPath triggers
+        java.awt.geom.Path2D
+        -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-awt</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkiverse.tika</groupId>
             <artifactId>quarkus-tika</artifactId>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -17,10 +17,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-awt</artifactId>
-        </dependency>
         <!-- the tika parsers depend on http-client -->
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
It is added in the integration tests though.

This is a followup from the work of Karm on AWT.