### PR TITLE
Disable cache for ecosystem CI for now

### DIFF
--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -34,7 +34,6 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
-          cache: 'maven'
 
       - name: Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Apparently, it needs a checkout of the project right away, we need to
understand better how this works.