### PR TITLE
Improve Tika Processor

### DIFF
--- a/deployment/src/test/java/io/quarkus/tika/deployment/TikaProcessorTest.java
+++ b/deployment/src/test/java/io/quarkus/tika/deployment/TikaProcessorTest.java
@@ -119,8 +119,8 @@ public class TikaProcessorTest {
 
     @Test
     public void testUnhyphenation() {
-        assertEquals("sortByPosition", TikaProcessor.unhyphenate("sort-by-position"));
-        assertEquals("position", TikaProcessor.unhyphenate("position"));
+        assertEquals("sortByPosition", TikaProcessor.camelCase("sort-by-position"));
+        assertEquals("position", TikaProcessor.camelCase("position"));
     }
 
     private Set<String> getParserNames(String tikaConfigPath, String parsers) throws Exception {

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -53,7 +53,7 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
                 <version>${quarkus.version}</version>
                 <executions>
                     <execution>


### PR DESCRIPTION
- Refactored the `TikaProcessor` class to use `camelCase` instead of `unhyphenate`
- Fixes the `java.io.UnsupportedEncodingException: windows-1252` when running the native tests
