### PR TITLE
Upgrade to Quarkus 3.0.4.Final

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.0.0.Final
+:quarkus-version: 3.0.4.Final
 :quarkus-tika-version: 2.0.1
 
 :quarkus-org-url: https://github.com/quarkusio

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>3.0.0.Final</quarkus.version>
+        <quarkus.version>3.0.4.Final</quarkus.version>
 
         <quarkus.poi.version>2.0.2</quarkus.poi.version>
         <tika.version>2.8.0</tika.version>


### PR DESCRIPTION
Does anyone mind pulling the Quarkus version up to 3.1.0.Final or at least something else than the current 3.0.0.Final? With 3.0.0.Final creating the Maven project in the guide (https://quarkiverse.github.io/quarkiverse-docs/quarkus-tika/dev/index.html) fails because there doesn't seem to be a quarkus-maven-plugin:3.0.0.Final (the Quarkus version is copied over there).