### PR TITLE
Add org.apache.tika:tika-parser-html-commons to runtime dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.tika</groupId>
+                <artifactId>tika-parser-html-commons</artifactId>
+                <version>${tika.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tika</groupId>
                 <artifactId>tika-parser-image-module</artifactId>
                 <version>${tika.version}</version>
             </dependency>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -65,6 +65,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.tika</groupId>
+            <artifactId>tika-parser-html-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
             <artifactId>tika-parser-image-module</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
This is mainly motivated by some usage of `BoilerpipeContentHandler` in the Apache Camel Quarkus Tika component extension (which depends on `quarkus-tika`). 

The class used was moved in Tika 2.5.0 from `org.apache.tika:tika-parser-html-module` to `org.apache.tika:tika-parser-html-commons`.