### PR TITLE
Fix all asciidoc warnings

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,4 @@
+:maven-version: 3.9.2
 :quarkus-version: 3.0.4.Final
 :quarkus-tika-version: 2.0.1
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -18,7 +18,7 @@ If you are planning to run the application as a native executable and parse docu
 ----
 
 When building native images in Docker using the standard Quarkus Docker configuration files some additional features need to be
-installed to support Apache POI.  Specifically font information is not included in [Red Hat's ubi-minimal images](https://developers.redhat.com/products/rhel/ubi).  To install it
+installed to support Apache POI. Specifically font information is not included in [Red Hat's ubi-minimal images](https://developers.redhat.com/products/rhel/ubi). To install it
 simply add these lines to your `DockerFile.native` file:
 
 [source]


### PR DESCRIPTION
Asciidoc interprets strings like ${maven-version} as attributes and then issues a WARN during the build that it will skip reference to a missing attribute. This PR adds a missing attribute to the `attributes.adoc` file.

Proof of all warnings gone:
<img width="923" alt="image" src="https://github.com/quarkiverse/quarkus-tika/assets/11942401/3699dc9f-bd9b-4ec4-bdbf-0a4872dc718e">

Proof of warnings before this PR:
<img width="937" alt="image" src="https://github.com/quarkiverse/quarkus-tika/assets/11942401/dc0cd640-73b2-430e-ad55-54da84e75351">
