### PR TITLE
Use `graal-sdk` instead of `svm`

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -114,8 +114,8 @@
             <artifactId>log4j2-jboss-logmanager</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
- Caused by https://github.com/quarkusio/quarkus/pull/34145