### PR TITLE
More fine grain registration for run time initialization

### DIFF
--- a/runtime/src/main/java/io/quarkus/tika/runtime/graal/TikaFeature.java
+++ b/runtime/src/main/java/io/quarkus/tika/runtime/graal/TikaFeature.java
@@ -6,9 +6,17 @@ import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
 public class TikaFeature implements Feature {
     @Override
     public void afterRegistration(AfterRegistrationAccess access) {
-        final String reason = "Quarkus run time init for Apache Tika";
-        RuntimeClassInitialization.initializeAtRunTime("org.apache.pdfbox.pdmodel", reason);
-        RuntimeClassInitialization.initializeAtRunTime("org.apache.pdfbox.rendering", reason);
+        RuntimeClassInitialization.initializeAtRunTime(
+                "org.apache.pdfbox.pdmodel",
+                "org.apache.pdfbox.rendering.GlyphCache",
+                "org.apache.pdfbox.rendering.GroupGraphics",
+                "org.apache.pdfbox.rendering.PDFRenderer",
+                "org.apache.pdfbox.rendering.PageDrawer",
+                "org.apache.pdfbox.rendering.PageDrawerParameters",
+                "org.apache.pdfbox.rendering.RenderDestination",
+                "org.apache.pdfbox.rendering.SoftMask",
+                "org.apache.pdfbox.rendering.TilingPaint",
+                "org.apache.pdfbox.rendering.TilingPaintFactory");
     }
 
     @Override


### PR DESCRIPTION
Registering `org.apache.pdfbox.rendering` for runtime initialization
results in errors like the following when using native-image's
`--strict-image-heap` option (which will be the default in future
GraalVM releases)

```
com.oracle.svm.core.util.UserError$UserException: An object of type 'org.apache.pdfbox.rendering.ImageType$2' was found in the image heap. This type, however, is marked for initialization at image run time for the following reason: classes are initialized at run time by default.
This is not allowed for correctness reasons: All objects that are stored in the image heap must be initialized at build time.

You now have two options to resolve this:

1) If it is intended that objects of type 'org.apache.pdfbox.rendering.ImageType$2' are persisted in the image heap, add

    '--initialize-at-build-time=org.apache.pdfbox.rendering.ImageType$2'

to the native-image arguments. Note that initializing new types can store additional objects to the heap. It is advised to check the static fields of 'org.apache.pdfbox.rendering.ImageType$2' to see if they are safe for build-time initialization,  and that they do not contain any sensitive data that should not become part of the image.

2) If these objects should not be stored in the image heap, you can use

    '--trace-object-instantiation=org.apache.pdfbox.rendering.ImageType$2'

to find classes that instantiate these objects. Once you found such a class, you can mark it explicitly for run time initialization with

    '--initialize-at-run-time=<culprit>'

to prevent the instantiation of the object.

If you are seeing this message after enabling '--strict-image-heap', this means that some objects ended up in the image heap without their type being marked with --initialize-at-build-time.
To fix this, include '--initialize-at-build-time=org.apache.pdfbox.rendering.ImageType$2' in your configuration. If the classes do not originate from your code, it is advised to update all library or framework dependencies to the latest version before addressing this error.
Please address this problem to be prepared for future releases of GraalVM.
```

This happens because Quarkus registers everything for build time
initialization while quarkus-tika asks for classes under the package
`org.apache.pdfbox.rendering` to be runtime initialized. However,
`org.apache.pdfbox.rendering.ImageType` seems to be instantiated from
classes outside of the package `org.apache.pdfbox.rendering` which are
marked for build time initialization resulting in the above error. By
not registering `org.apache.pdfbox.rendering.ImageType` for runtime
initialization we allow it to be build time instantiated, resolving the
issue.

Since `org.apache.pdfbox.rendering.ImageType` relies only on
`java.awt.image.BufferedImage` we are not risking build time
initialization of many `java.awt` classes that are known to not work
well with build time initialization.

Closes https://github.com/quarkiverse/quarkus-tika/issues/168
