### PR TITLE
Refactor dependencies and update documentation versions

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -35,7 +35,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-http-dev-ui-spi</artifactId>
+            <artifactId>quarkus-devui-deployment-spi</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.20.2
+:quarkus-version: 3.27.0
 :quarkus-tika-version: 2.2.1
 
 :quarkus-org-url: https://github.com/quarkusio

--- a/pom.xml
+++ b/pom.xml
@@ -141,21 +141,6 @@
                 <artifactId>tika-parser-webarchive-module</artifactId>
                 <version>${tika.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.28.0</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.luben</groupId>
-                <artifactId>zstd-jni</artifactId>
-                <version>1.5.7-4</version>
-            </dependency>
-            <dependency>
-                <groupId>org.tukaani</groupId>
-                <artifactId>xz</artifactId>
-                <version>1.10</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
     <build>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -118,14 +118,6 @@
             <artifactId>log4j2-jboss-logmanager</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.luben</groupId>
-            <artifactId>zstd-jni</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.tukaani</groupId>
-            <artifactId>xz</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.graalvm.sdk</groupId>
             <artifactId>graal-sdk</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
- Remove transitive dependencies: `commons-compress`, `zstd-jni`, and `xz` to streamline project dependencies.
- Update Quarkus version in documentation to `3.27.0` for accurate versioning.
- Replace `quarkus-vertx-http-dev-ui-spi` with `quarkus-devui-deployment-spi` to reflect new module name
