### PR TITLE
docs: define missing maven-version attribute

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,5 +1,6 @@
 :quarkus-version: 2.16.5.Final
 :quarkus-tika-version: 1.1.1
+:maven-version: 3.9.9
 
 :quarkus-org-url: https://github.com/quarkusio
 :quarkus-base-url: {quarkus-org-url}/quarkus


### PR DESCRIPTION
## Summary
- Add missing `maven-version` attribute to `docs/modules/ROOT/pages/includes/attributes.adoc`
- The attribute is referenced in `index.adoc` (`Apache Maven {maven-version}`)

This warning appears during the quarkiverse-docs Antora build.

Backport of the same fix applied to the `main` branch.